### PR TITLE
Update VESC calibration parameters for red truck

### DIFF
--- a/carma_vesc_ssc_wrapper/config/vesc_wrapper.params.yaml
+++ b/carma_vesc_ssc_wrapper/config/vesc_wrapper.params.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     speed_to_erpm_gain: 7317.8
     speed_to_erpm_offset: 0.0
-    steering_angle_to_servo_gain: -1.2135
+    steering_angle_to_servo_gain: -0.9135
     steering_angle_to_servo_offset: 0.425
     wheelbase: 0.3175
     max_erpm_positive_delta: 500.0  # limits the sudden acceleration in rpm

--- a/carma_vesc_ssc_wrapper/config/vesc_wrapper.params.yaml
+++ b/carma_vesc_ssc_wrapper/config/vesc_wrapper.params.yaml
@@ -1,9 +1,9 @@
 /**:
   ros__parameters:
-    speed_to_erpm_gain: 4615.0
+    speed_to_erpm_gain: 7317.8
     speed_to_erpm_offset: 0.0
-    steering_angle_to_servo_gain: -0.9135
-    steering_angle_to_servo_offset: 0.48
+    steering_angle_to_servo_gain: -1.2135
+    steering_angle_to_servo_offset: 0.425
     wheelbase: 0.3175
     max_erpm_positive_delta: 500.0  # limits the sudden acceleration in rpm
     max_erpm_negative_delta: 1000.0 # limits the sudden deceleration in rpm


### PR DESCRIPTION
# PR Details
## Description

This PR updates the VESC parameters for the red C1T truck. The parameters were empirically determined.

## Related GitHub Issue

## Related Jira Key

Closes [CF-692](https://usdot-carma.atlassian.net/browse/CF-692)

## Motivation and Context

The default VESC Ackermann-to-vesc parameters are invalid for the red truck.

## How Has This Been Tested?

Manually using a crude evaluation setup. There was tape of the floor spaced one meter apart. The truck was started some distance away from the first piece of tape to allow the truck to get up to the commanded speed. Once the truck crossed the tape, a timer was started. The timer stopped when the truck crossed the second line of tape.

## Types of changes

- [x] Config change

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CF-692]: https://usdot-carma.atlassian.net/browse/CF-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ